### PR TITLE
Add support for server -> client RemoteFunctions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ selene.toml
 roblox.toml
 *.rbxlx
 *.rbxl
+*.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 \.vscode/
 selene.toml
 roblox.toml
+*.rbxlx
+*.rbxl

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-
 \.vscode/
+selene.toml
+roblox.toml

--- a/src/Client/Core/DragonEngine.client.lua
+++ b/src/Client/Core/DragonEngine.client.lua
@@ -52,6 +52,7 @@ end
 -- DEFINES --
 -------------
 local Service_Endpoints=ReplicatedStorage.DragonEngine.Network.Service_Endpoints
+local Service_ClientEndpoints = ReplicatedStorage.DragonEngine.Network.Service_ClientEndpoints
 
 local Service_Loaded=ReplicatedStorage.DragonEngine.Network.ServiceLoaded.OnClientEvent --Fired when a service is loaded.
 DragonEngine.ServiceLoaded=Service_Loaded
@@ -76,7 +77,8 @@ local function ConnectToServiceEndpoints(ServiceName)
 	-------------
 	-- DEFINES --
 	-------------
-	local ServiceFolder=Service_Endpoints[ServiceName]
+	local Service_EndpointFolder = Service_Endpoints[ServiceName]
+	local Service_ClientEndpointFolder = Service_ClientEndpoints[ServiceName]
 
 	-----------------------------
 	-- Connecting to endpoints --
@@ -84,21 +86,34 @@ local function ConnectToServiceEndpoints(ServiceName)
 	DragonEngine:DebugLog("Connecting to endpoints for service '"..ServiceName.."'")
 	local Service={}
 
-	for _,RemoteFunction in pairs(ServiceFolder:GetChildren()) do
+	for _,RemoteFunction in pairs(Service_EndpointFolder:GetChildren()) do
 		if RemoteFunction:IsA("RemoteFunction") then
-			DragonEngine:DebugLog("Connecting to remote function '"..ServiceFolder.Name.."."..RemoteFunction.Name.."'...")
+			DragonEngine:DebugLog("Connecting to remote function '"..Service_EndpointFolder.Name.."."..RemoteFunction.Name.."'...")
 
 			Service[RemoteFunction.Name]=function(self,...) --We seperate 'self' to ommit it from the server call.
 				return RemoteFunction:InvokeServer(...)
 			end
 		elseif RemoteFunction:IsA("RemoteEvent") then
-			DragonEngine:DebugLog("Registered remote event '"..ServiceFolder.Name.."."..RemoteFunction.Name.."'.")
+			DragonEngine:DebugLog("Registered remote event '"..Service_EndpointFolder.Name.."."..RemoteFunction.Name.."'.")
 			Service[RemoteFunction.Name]=RemoteFunction.OnClientEvent
 		end
 	end
 
-	DragonEngine.Services[ServiceFolder.Name]=Service
+	DragonEngine.Services[Service_EndpointFolder.Name]=Service
 	DragonEngine:DebugLog("Connected to all endpoints for service '"..ServiceName.."'.")
+
+	------------------------------------------
+	-- Registering service client endpoints --
+	------------------------------------------
+	DragonEngine:DebugLog("Registering client endpoints for service '"..ServiceName.."'")
+
+	for _,RemoteFunction in pairs(Service_ClientEndpointFolder:GetChildren()) do
+		if RemoteFunction:IsA("RemoteFunction") then
+			Service[RemoteFunction.Name] = RemoteFunction
+
+			DragonEngine:DebugLog("Registered client endpoint '"..RemoteFunction.Name.."' for service '"..ServiceName.."'")
+		end
+	end
 end
 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/Server/Core/DragonEngine.server.lua
+++ b/src/Server/Core/DragonEngine.server.lua
@@ -35,7 +35,9 @@ local Service_Endpoints=Instance.new('Folder',ReplicatedStorage.DragonEngine.Net
 Service_Endpoints.Name="Service_Endpoints"
 local Service_Events=Instance.new('Folder',ServerScriptService.DragonEngine) --A folder containing the server sided events for services.
 Service_Events.Name="Service_Events"
-
+local Service_ClientEndpoints = Instance.new('Folder')
+	  Service_ClientEndpoints.Name = "Service_ClientEndpoints"
+	  Service_ClientEndpoints.Parent = ReplicatedStorage.DragonEngine.Network
 local Service_Loaded_ServerEvent=Instance.new('BindableEvent') --Bindable event for signalling server services when a service is loaded.
 DragonEngine.ServiceLoaded=Service_Loaded_ServerEvent.Event
 local Service_Unloaded_ServerEvent=Instance.new('BindableEvent') --Bindable event for signalling server services when a service is unloaded.
@@ -124,6 +126,14 @@ function DragonEngine:LoadService(ServiceModule)
 				end
 			end
 		end
+
+		---------------------------------
+		-- Generating client endpoints --
+		---------------------------------
+		local Client_EndpointFolder = Instance.new('Folder')
+		      Client_EndpointFolder.Name = ServiceName
+			  Client_EndpointFolder.Parent = Service_ClientEndpoints
+		Service._ClientEndpointFolder = Client_EndpointFolder
 
 		---------------------------------------------
 		-- Adding service to DragonEngine.Services --
@@ -341,6 +351,29 @@ function DragonEngine:StopService(ServiceName)
 	return true
 end
 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- @Name : RegisterClientEndpoint
+-- @Description : Registers a client endpoint for the service calling that the server can invoke to get client information.
+--!               USE THIS WITH CAUTION. USING THE CLIENT AS A SOURCE OF TRUTH IS DANGEROUS.
+-- @Params : string "EndpointName" - The name to assign to the endpoint
+-- @Returns : Instance <RemoteFunction> "RemoteFunction" - The registered client endpoint.
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+function DragonEngine:RegisterClientEndpoint(EndpointName)
+	
+	----------------
+	-- Assertions --
+	----------------
+	assert(EndpointName ~= nil, "[Dragon Engine Server] RegisterClientEndpoint() : string Expected for 'EndpointName', got nil instead.")
+	assert(typeof(EndpointName) == "string", "[Dragon Engine Server] RegisterClientEndpoint() : string expected for 'EndpointName', got "..typeof(EndpointName).." instead.")
+
+	local RemoteFunction = Instance.new('RemoteFunction')
+		  RemoteFunction.Name = EndpointName
+		  RemoteFunction.Parent = self._ClientEndpointFolder
+
+	self:DebugLog("Registered client endpoint '"..EndpointName.."' for service '"..self.Name.."'")
+
+	return RemoteFunction
+end
 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- @Name : RegisterServiceClientEvent


### PR DESCRIPTION
Closes #47.

This adds a new method to the framework's server API called `RegisterClientEndpoint`. It behaves similarly to `RegisterServiceClientEvent`. Calling `RegisterClientEndpoint` will register a RemoteFunction that the server can call `:InvokeClient()` on. The relevant controller on the client will be 'listening' to it via `.OnClientInvoke`.

This PR also adds a few files to `.gitignore`, since they were not in it previously.