### PR TITLE
Add method 'GetService'

### DIFF
--- a/src/Client/Core/DragonEngine.client.lua
+++ b/src/Client/Core/DragonEngine.client.lua
@@ -128,6 +128,15 @@ end
 -- DEFINES --
 -------------
 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- @Name : GetService
+-- @Description : Returns the requested service
+-- @Params : string "ServiceName" - The name of the service to retrieve
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+function DragonEngine:GetService(ServiceName)
+	assert(DragonEngine.Services[ServiceName] ~= nil,"[Dragon Engine Client] GetService() : Service '"..ServiceName.."' was not loaded or does not exist.")
+	return DragonEngine.Services[ServiceName]
+end
 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- @Name: GetController


### PR DESCRIPTION
This PR adds the client method `GetService`. This method allows client modules/controllers to call `DragonEngine:GetService(ServiceName)`, which is now the standard convention. Similiar to `DragonEngine:GetService(ServiceName)` on the server.